### PR TITLE
Add LanguageClient.txt target to help doc

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -1,4 +1,4 @@
-*LanguageClient*  Language Server Protocol support for neovim
+*LanguageClient.txt*    Language Server Protocol support for neovim    *LanguageClient*
 
 
 ==============================================================================


### PR DESCRIPTION
When the help document is indexed, Vim will automatically create a "LanguageClient.txt" tag, which you can use to jump to the help via `:help LanguageClient.txt`. This commit adds this tag to the doc, because without it, Vim will open the help doc but show "E434: Can't find tag pattern".

To see this pattern in action, open up pretty much any help file that comes with Vim; for example, here is the first line of "usr_01.txt" that comes with Vim:

```
*usr_01.txt*	For Vim version 8.1.  Last change: 2017 Jul 15
```

and the equivalent file from Neovim:

```
*usr_01.txt*	Nvim
```